### PR TITLE
Feature/read out settings

### DIFF
--- a/src/StrokeEngine.cpp
+++ b/src/StrokeEngine.cpp
@@ -61,6 +61,10 @@ void StrokeEngine::setSpeed(float speed) {
 
 }
 
+float StrokeEngine::getSpeed() {
+    return 60.0 / _timeOfStroke;
+}
+
 void StrokeEngine::setDepth(float depth) {
     // Convert depth from mm into steps
     _depth = int(depth * _motor->stepsPerMillimeter);
@@ -74,6 +78,10 @@ void StrokeEngine::setDepth(float depth) {
 #ifdef DEBUG_VERBOSE
     Serial.println("setDepth: " + String(_depth));
 #endif
+}
+
+float StrokeEngine::getDepth() {
+    return _depth / _motor->stepsPerMillimeter;
 }
 
 void StrokeEngine::setStroke(float stroke) {
@@ -91,6 +99,10 @@ void StrokeEngine::setStroke(float stroke) {
 #endif
 }
 
+float StrokeEngine::getStroke() {
+    return _stroke / _motor->stepsPerMillimeter;
+}
+
 void StrokeEngine::setSensation(float sensation) {
     // Constrain sensation between -100 and 100
     _sensation = constrain(sensation, -100, 100); 
@@ -101,6 +113,10 @@ void StrokeEngine::setSensation(float sensation) {
 #ifdef DEBUG_VERBOSE
     Serial.println("setSensation: " + String(_sensation));
 #endif
+}
+
+float StrokeEngine::getSensation() {
+    return _sensation;
 }
 
 bool StrokeEngine::setPattern(int patternIndex) {
@@ -132,6 +148,10 @@ bool StrokeEngine::setPattern(int patternIndex) {
     Serial.println("Failed to set pattern: " + String(_patternIndex));
 #endif
     return false;   
+}
+
+int StrokeEngine::getPattern() {
+    return _patternIndex;
 }
 
 bool StrokeEngine::applyNewSettingsNow() {

--- a/src/StrokeEngine.h
+++ b/src/StrokeEngine.h
@@ -110,6 +110,14 @@ class StrokeEngine {
 
         /**************************************************************************/
         /*!
+          @brief  Get the speed of a stroke. Speed is returned as Strokes per Minute. 
+          @return Strokes per Minute.
+        */
+        /**************************************************************************/
+        float getSpeed();
+
+        /**************************************************************************/
+        /*!
           @brief  Set the depth of a stroke. Settings tale effect with next stroke, 
           or after calling applyNewSettingsNow().
           @param speed Depth in [mm]. Is constrained from 0 to TRAVEL 
@@ -119,12 +127,28 @@ class StrokeEngine {
 
         /**************************************************************************/
         /*!
+          @brief  Get the depth of a stroke.
+          @return Depth in [mm].
+        */
+        /**************************************************************************/
+        float getDepth();
+
+        /**************************************************************************/
+        /*!
           @brief  Set the stroke length of a stroke. Settings tale effect with next 
           stroke, or after calling applyNewSettingsNow().
           @param speed Stroke length in [mm]. Is constrained from 0 to TRAVEL 
         */
         /**************************************************************************/
         void setStroke(float stroke);
+
+        /**************************************************************************/
+        /*!
+          @brief  Get the stroke length of a stroke.
+          @return Stroke length in [mm].
+        */
+        /**************************************************************************/
+        float getStroke();
 
         /**************************************************************************/
         /*!
@@ -139,6 +163,16 @@ class StrokeEngine {
 
         /**************************************************************************/
         /*!
+          @brief  Get the sensation of a pattern. Sensation is an additional 
+          parameter a pattern may use to alter its behaviour.
+          @return Sensation in [a.u.]. Is constrained from -100 to 100  
+                        with 0 beeing assumed as neutral.
+        */
+        /**************************************************************************/
+        float getSensation();
+
+        /**************************************************************************/
+        /*!
           @brief  Choose a pattern for the StrokeEngine. Settings take effect with 
           next stroke, or after calling applyNewSettingsNow(). 
           @param patternIndex  Index of a pattern
@@ -147,6 +181,14 @@ class StrokeEngine {
         */
         /**************************************************************************/
         bool setPattern(int patternIndex);
+
+        /**************************************************************************/
+        /*!
+          @brief  Get the pattern index for the StrokeEngine.
+          @return Index of a pattern
+        */
+        /**************************************************************************/
+        int getPattern();
 
         /**************************************************************************/
         /*!


### PR DESCRIPTION
**Introduction**
This pull request makes it possible to read out the values used in the stroke engine.

The main use case is to only calculate constraints in one place. If for example depth is set beyond travel, the stroke engine will constrain it, but the service whom gave the order will not know that. Now it becomes possible to return the value and correctly display it.